### PR TITLE
test(ssh-gateway): stop TestSandboxAcceptsSFTPSubsystem flaking on the shared FakeExecutor

### DIFF
--- a/lego/backend/internal/sshgateway/gatewaytest/fakes.go
+++ b/lego/backend/internal/sshgateway/gatewaytest/fakes.go
@@ -125,20 +125,34 @@ func (f *FakeResolver) ResolveSSHSession(ctx context.Context, username string) (
 // FakeExecutor implements Executor. In TTY mode it reads two terminal sizes
 // before writing output — both the native SSH and webshell suites depend on
 // that contract to observe resize propagation.
+//
+// Execute runs on the gateway's connection goroutine, so what it records is
+// read from a different goroutine than the one that writes it. The recorded
+// state is therefore private behind mu, like FakeStore's above, and reached
+// through Args/UsedTTY/TerminalSizes. A test that asserts on it must first
+// wait for the exec to arrive: serveSession replies to the pty/exec/subsystem
+// request BEFORE runExec calls the executor, so a client call returning is not
+// evidence that Execute has run.
 type FakeExecutor struct {
-	Command []string
-	TTY     bool
-	Sizes   []remotecommand.TerminalSize
 	Code    int
 	Err     error
 	Block   bool
 	Started chan struct{}
 	Stopped chan error
+
+	mu      sync.Mutex
+	invoked chan struct{}
+	command []string
+	tty     bool
+	sizes   []remotecommand.TerminalSize
 }
 
 func (f *FakeExecutor) Execute(ctx context.Context, _ apps.SSHInstanceTarget, command []string, tty bool, queue remotecommand.TerminalSizeQueue, _ io.Reader, stdout, _ io.Writer) (int, error) {
-	f.Command = append([]string(nil), command...)
-	f.TTY = tty
+	f.mu.Lock()
+	f.command = append([]string(nil), command...)
+	f.tty = tty
+	f.mu.Unlock()
+	f.markInvoked()
 	if f.Started != nil {
 		select {
 		case f.Started <- struct{}{}:
@@ -153,15 +167,79 @@ func (f *FakeExecutor) Execute(ctx context.Context, _ apps.SSHInstanceTarget, co
 		return 126, ctx.Err()
 	}
 	if tty {
-		if size := queue.Next(); size != nil {
-			f.Sizes = append(f.Sizes, *size)
-		}
-		if size := queue.Next(); size != nil {
-			f.Sizes = append(f.Sizes, *size)
+		for range 2 {
+			if size := queue.Next(); size != nil {
+				f.mu.Lock()
+				f.sizes = append(f.sizes, *size)
+				f.mu.Unlock()
+			}
 		}
 	}
 	if f.Err == nil {
 		_, _ = io.WriteString(stdout, "inside-app\n")
 	}
 	return f.Code, f.Err
+}
+
+// Args returns a copy of the argv the gateway last handed the executor, or nil
+// when Execute has not been reached.
+func (f *FakeExecutor) Args() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.command...)
+}
+
+// UsedTTY reports whether the last exec asked for a TTY.
+func (f *FakeExecutor) UsedTTY() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.tty
+}
+
+// TerminalSizes returns a copy of the sizes the exec stream pulled off the
+// resize queue.
+func (f *FakeExecutor) TerminalSizes() []remotecommand.TerminalSize {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]remotecommand.TerminalSize(nil), f.sizes...)
+}
+
+// WaitInvoked blocks until Execute has recorded an invocation, and reports
+// whether it arrived within timeout. It is the happens-before edge an assertion
+// on Args/UsedTTY needs when the client call it followed only proves the
+// request was ACKNOWLEDGED — the subsystem and pty paths both reply first and
+// exec after.
+func (f *FakeExecutor) WaitInvoked(timeout time.Duration) bool {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-f.invokedChan():
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+// invokedChan returns the channel closed by the first Execute call, creating it
+// on demand so a zero-value FakeExecutor stays usable.
+func (f *FakeExecutor) invokedChan() chan struct{} {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.invoked == nil {
+		f.invoked = make(chan struct{})
+	}
+	return f.invoked
+}
+
+func (f *FakeExecutor) markInvoked() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.invoked == nil {
+		f.invoked = make(chan struct{})
+	}
+	select {
+	case <-f.invoked:
+	default:
+		close(f.invoked)
+	}
 }

--- a/lego/backend/internal/sshgateway/gatewaytest/fakes_test.go
+++ b/lego/backend/internal/sshgateway/gatewaytest/fakes_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gatewaytest
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"k8s.io/client-go/tools/remotecommand"
+
+	"github.com/bex-co/bex/lego/backend/internal/apps"
+)
+
+// sizeQueue serves a fixed list of terminal sizes and then blocks forever, the
+// contract remotecommand expects of a resize queue.
+type sizeQueue struct {
+	sizes []remotecommand.TerminalSize
+	done  chan struct{}
+}
+
+func (q *sizeQueue) Next() *remotecommand.TerminalSize {
+	if len(q.sizes) == 0 {
+		<-q.done
+		return nil
+	}
+	size := q.sizes[0]
+	q.sizes = q.sizes[1:]
+	return &size
+}
+
+// execAsGateway calls Execute the way the gateway does: on another goroutine,
+// after the request that triggered it has already been acknowledged.
+func execAsGateway(t *testing.T, exec *FakeExecutor, command []string, tty bool, queue remotecommand.TerminalSizeQueue) {
+	t.Helper()
+	go func() {
+		_, _ = exec.Execute(context.Background(), apps.SSHInstanceTarget{}, command, tty, queue, nil, io.Discard, io.Discard)
+	}()
+}
+
+// The gateway ACKs a pty/exec/subsystem request before runExec reaches the
+// executor, so a test that asserts on the recorded argv has to wait for the
+// exec itself. WaitInvoked is that edge: after it returns true the argv is
+// fully recorded, never a partially written or nil slice.
+func TestFakeExecutorWaitInvokedPrecedesRecordedArgs(t *testing.T) {
+	exec := &FakeExecutor{}
+	want := []string{"/bin/sh", "-c", `cd "${HOME:-/home/bex}" && exec /usr/lib/openssh/sftp-server`}
+	execAsGateway(t, exec, want, false, nil)
+
+	if !exec.WaitInvoked(2 * time.Second) {
+		t.Fatal("WaitInvoked did not observe the exec")
+	}
+	argv := exec.Args()
+	if len(argv) != len(want) {
+		t.Fatalf("argv = %#v, want %#v", argv, want)
+	}
+	for i := range want {
+		if argv[i] != want[i] {
+			t.Fatalf("argv = %#v, want %#v", argv, want)
+		}
+	}
+}
+
+// The null case: with no exec at all, WaitInvoked reports the miss instead of
+// letting an assertion run against unrecorded state.
+func TestFakeExecutorWaitInvokedReportsNoExec(t *testing.T) {
+	exec := &FakeExecutor{}
+	if exec.WaitInvoked(50 * time.Millisecond) {
+		t.Fatal("WaitInvoked reported an exec that never happened")
+	}
+	if argv := exec.Args(); argv != nil {
+		t.Fatalf("argv = %#v, want nil before any exec", argv)
+	}
+	if exec.UsedTTY() {
+		t.Fatal("UsedTTY reported a TTY before any exec")
+	}
+}
+
+// A second exec over the same connection must not re-arm or block WaitInvoked.
+func TestFakeExecutorWaitInvokedStaysSatisfiedAcrossExecs(t *testing.T) {
+	exec := &FakeExecutor{}
+	execAsGateway(t, exec, []string{"/bin/sh", "-lc", "first"}, false, nil)
+	if !exec.WaitInvoked(2 * time.Second) {
+		t.Fatal("WaitInvoked did not observe the first exec")
+	}
+	execAsGateway(t, exec, []string{"/bin/sh", "-lc", "second"}, false, nil)
+	if !exec.WaitInvoked(2 * time.Second) {
+		t.Fatal("WaitInvoked stopped reporting after a second exec")
+	}
+}
+
+// TTY mode records the sizes it pulled off the resize queue, and the accessors
+// hand back copies so a caller cannot mutate the fake's state.
+func TestFakeExecutorRecordsTTYSizesAndReturnsCopies(t *testing.T) {
+	exec := &FakeExecutor{}
+	queue := &sizeQueue{sizes: []remotecommand.TerminalSize{{Width: 80, Height: 24}, {Width: 120, Height: 40}}}
+	execAsGateway(t, exec, []string{"/bin/sh"}, true, queue)
+	if !exec.WaitInvoked(2 * time.Second) {
+		t.Fatal("WaitInvoked did not observe the exec")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	var sizes []remotecommand.TerminalSize
+	for time.Now().Before(deadline) {
+		if sizes = exec.TerminalSizes(); len(sizes) == 2 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if len(sizes) != 2 || sizes[0].Width != 80 || sizes[1].Width != 120 {
+		t.Fatalf("terminal sizes = %+v, want widths 80 then 120", sizes)
+	}
+	if !exec.UsedTTY() {
+		t.Fatal("UsedTTY = false, want true for a pty exec")
+	}
+
+	sizes[0].Width = 1
+	if again := exec.TerminalSizes(); again[0].Width != 80 {
+		t.Fatalf("TerminalSizes handed out its own slice: width now %d", again[0].Width)
+	}
+	argv := exec.Args()
+	argv[0] = "tampered"
+	if again := exec.Args(); again[0] != "/bin/sh" {
+		t.Fatalf("Args handed out its own slice: argv now %#v", again)
+	}
+}

--- a/lego/backend/internal/sshgateway/nativessh/multichannel_test.go
+++ b/lego/backend/internal/sshgateway/nativessh/multichannel_test.go
@@ -196,14 +196,20 @@ func TestSandboxAcceptsSFTPSubsystem(t *testing.T) {
 	if err := session.RequestSubsystem("sftp"); err != nil {
 		t.Fatalf("sftp subsystem should be accepted for a sandbox target: %v", err)
 	}
+	// serveSession ACKs the subsystem request and only then runs the exec, so
+	// RequestSubsystem returning does not mean the executor has been called yet.
+	if !exec.WaitInvoked(2 * time.Second) {
+		t.Fatal("sftp subsystem was accepted but never reached the executor")
+	}
 	// Started via `sh -c 'cd "$HOME" && exec …/sftp-server'` so a relative upload
 	// path (Zed's `.zed_server/…`) resolves under $HOME, not the WORKDIR (w2/m65).
-	if len(exec.Command) != 3 || exec.Command[0] != "/bin/sh" || exec.Command[1] != "-c" {
-		t.Fatalf("sftp exec argv = %#v, want [/bin/sh -c <cd $HOME && exec sftp-server>]", exec.Command)
+	argv := exec.Args()
+	if len(argv) != 3 || argv[0] != "/bin/sh" || argv[1] != "-c" {
+		t.Fatalf("sftp exec argv = %#v, want [/bin/sh -c <cd $HOME && exec sftp-server>]", argv)
 	}
-	if !strings.Contains(exec.Command[2], "/usr/lib/openssh/sftp-server") ||
-		!strings.Contains(exec.Command[2], "HOME") {
-		t.Fatalf("sftp command should cd to $HOME then exec sftp-server, got %q", exec.Command[2])
+	if !strings.Contains(argv[2], "/usr/lib/openssh/sftp-server") ||
+		!strings.Contains(argv[2], "HOME") {
+		t.Fatalf("sftp command should cd to $HOME then exec sftp-server, got %q", argv[2])
 	}
 	_ = session.Close()
 }

--- a/lego/backend/internal/sshgateway/nativessh/server_test.go
+++ b/lego/backend/internal/sshgateway/nativessh/server_test.go
@@ -247,8 +247,8 @@ func TestGatewayExecPropagatesIdentityOutputExitAndAudit(t *testing.T) {
 	if string(output) != "inside-app\n" || resolver.Subject != "user-1" || resolver.Username != "srv-abcdeabcdeabcdeabcde" {
 		t.Fatalf("output/identity/target = %q %q %q", output, resolver.Subject, resolver.Username)
 	}
-	if len(executor.Command) != 3 || executor.Command[0] != "/bin/sh" || executor.Command[2] != "printf private-command" {
-		t.Fatalf("exec command = %#v", executor.Command)
+	if argv := executor.Args(); len(argv) != 3 || argv[0] != "/bin/sh" || argv[2] != "printf private-command" {
+		t.Fatalf("exec command = %#v", argv)
 	}
 	time.Sleep(20 * time.Millisecond)
 	started, ended := st.StartedSessions(), st.EndedSessions()
@@ -280,8 +280,8 @@ func TestGatewayPTYResizeAndShell(t *testing.T) {
 	if err := session.Wait(); err != nil {
 		t.Fatal(err)
 	}
-	if !executor.TTY || len(executor.Sizes) != 2 || executor.Sizes[0].Width != 80 || executor.Sizes[1].Width != 120 {
-		t.Fatalf("tty/sizes = %v %+v", executor.TTY, executor.Sizes)
+	if sizes := executor.TerminalSizes(); !executor.UsedTTY() || len(sizes) != 2 || sizes[0].Width != 80 || sizes[1].Width != 120 {
+		t.Fatalf("tty/sizes = %v %+v", executor.UsedTTY(), sizes)
 	}
 }
 
@@ -303,8 +303,8 @@ func TestGatewayRejectsTerminalDimensionsThatWouldOverflowKubernetes(t *testing.
 	if err := session.RequestPty("xterm", 24, 70000, ssh.TerminalModes{}); err == nil {
 		t.Fatal("oversized PTY width was accepted")
 	}
-	if len(executor.Command) != 0 {
-		t.Fatalf("oversized PTY reached executor: %#v", executor.Command)
+	if argv := executor.Args(); len(argv) != 0 {
+		t.Fatalf("oversized PTY reached executor: %#v", argv)
 	}
 }
 
@@ -387,8 +387,8 @@ func TestGatewayRejectsUnsupportedRequestsBeforeExec(t *testing.T) {
 	if err != nil || string(output) != "inside-app\n" {
 		t.Fatalf("valid exec after rejected requests = %q, %v", output, err)
 	}
-	if len(executor.Command) != 3 || executor.Command[2] != "true" {
-		t.Fatalf("executor received unexpected command: %#v", executor.Command)
+	if argv := executor.Args(); len(argv) != 3 || argv[2] != "true" {
+		t.Fatalf("executor received unexpected command: %#v", argv)
 	}
 }
 
@@ -412,8 +412,8 @@ func TestGatewayRejectsSCPProtocolBeforeExec(t *testing.T) {
 			if err := session.Run(command); err == nil {
 				t.Fatal("SCP protocol command unexpectedly accepted")
 			}
-			if executor.Command != nil {
-				t.Fatalf("SCP protocol reached executor: %#v", executor.Command)
+			if argv := executor.Args(); argv != nil {
+				t.Fatalf("SCP protocol reached executor: %#v", argv)
 			}
 		})
 	}

--- a/lego/backend/internal/sshgateway/webshell/websocket_test.go
+++ b/lego/backend/internal/sshgateway/webshell/websocket_test.go
@@ -117,11 +117,12 @@ func TestWebSocketShellHappyPath(t *testing.T) {
 	if exitCode != 0 {
 		t.Errorf("exit code = %d, want 0", exitCode)
 	}
-	if !exec.TTY || len(exec.Command) != 1 || exec.Command[0] != "/bin/sh" {
-		t.Errorf("executor got tty=%v command=%v, want an interactive /bin/sh", exec.TTY, exec.Command)
+	argv := exec.Args()
+	if !exec.UsedTTY() || len(argv) != 1 || argv[0] != "/bin/sh" {
+		t.Errorf("executor got tty=%v command=%v, want an interactive /bin/sh", exec.UsedTTY(), argv)
 	}
-	if len(exec.Sizes) == 0 || exec.Sizes[len(exec.Sizes)-1].Width != 100 {
-		t.Errorf("resize not delivered to the exec stream: %+v", exec.Sizes)
+	if sizes := exec.TerminalSizes(); len(sizes) == 0 || sizes[len(sizes)-1].Width != 100 {
+		t.Errorf("resize not delivered to the exec stream: %+v", sizes)
 	}
 	if resolver.Subject != "user-1" || resolver.Username != "srv-abcdeabcdeabcdeabcde" {
 		t.Errorf("resolver saw subject=%q username=%q", resolver.Subject, resolver.Username)


### PR DESCRIPTION
This PR proposes stopping `TestSandboxAcceptsSFTPSubsystem` from failing intermittently, by making the shared SSH-gateway `FakeExecutor` safe to read from the test goroutine. We include this PR work along with a full history of your repo at https://eastagiletracker.com/projects/294. You can sign in with your GitHub ID to claim ownership of the project.

## What's wrong

`serveSession` acknowledges a `subsystem` request and only *then* calls `runExec`, which hands the argv to the executor — correct sshd ordering, and the same shape on the `pty-req` and `exec` paths. `TestSandboxAcceptsSFTPSubsystem` asserts immediately after `session.RequestSubsystem("sftp")` returns, so it reads `gatewaytest.FakeExecutor.Command` while the gateway goroutine may not have written it yet. There is no synchronisation on that field at all, so the read is also a data race.

That is not theoretical: `test (backend)` on `main` went red this way at 05:49 UTC on 2026-08-13 (run [31671403879](https://github.com/bex-co/bex/actions/runs/31671403879), commit `bfe1376c`), and passed again 18 minutes later on `a1633b0b` with no relevant change in between.

```
--- FAIL: TestSandboxAcceptsSFTPSubsystem (0.00s)
    multichannel_test.go:202: sftp exec argv = []string(nil), want [/bin/sh -c <cd $HOME && exec sftp-server>]
FAIL	github.com/bex-co/bex/lego/backend/internal/sshgateway/nativessh	0.297s
```

## Reproducing it on current `main`

At `1489774` (`main`, before this branch), in `lego/backend`:

```
$ go test -race -count=1 -run '^TestSandboxAcceptsSFTPSubsystem$' ./internal/sshgateway/nativessh/
WARNING: DATA RACE
Read at 0x00c000438380 by goroutine 15:
  ...nativessh.TestSandboxAcceptsSFTPSubsystem()
      .../nativessh/multichannel_test.go:201
Previous write at 0x00c000438380 by goroutine 19:
  ...gatewaytest.(*FakeExecutor).Execute()
      .../gatewaytest/fakes.go:140
  ...nativessh.runExec()
      .../nativessh/session.go:164
```

4 of 5 such runs reported the race. Without `-race`, the compiled test binary run 60 times in a loop failed **16 times**, each with the exact `argv = []string(nil)` message above. On a busier CI runner the executor goroutine usually wins the race, which is why this surfaces as an occasional red `main` rather than a permanently red test.

## The change

`FakeExecutor`'s recorded state (`Command`, `TTY`, `Sizes`) becomes private behind a mutex, reached through copy-returning `Args()`, `UsedTTY()` and `TerminalSizes()` — the same shape `FakeStore` in that file already uses for its audit rows. `WaitInvoked(timeout)` is added as the happens-before edge an assertion needs, and `TestSandboxAcceptsSFTPSubsystem` waits on it before asserting. The other call sites in the native SSH and webshell suites move to the accessors, so the unsynchronised read is gone rather than merely unlikely. The input fields (`Code`, `Err`, `Block`, `Started`, `Stopped`) are untouched, so the existing `Block: true` tests keep working unchanged. No production code is modified — the gateway's ACK-then-exec ordering is correct and stays as it is.

`internal/sshgateway/gatewaytest` had no tests of its own; this adds four, covering the ordering edge, the null case where no exec ever arrives, a second exec over the same connection, and that the accessors hand back copies rather than the fake's own slices.

## Verifying it

Regression evidence, since the failure is probabilistic: with only the behavioural line reverted (the record lock and the invocation signal removed, every new declaration kept), the three new ordering tests fail and the null-case control stays green. With the change in place they pass.

```
# without the fix's behavioural line
--- FAIL: TestFakeExecutorWaitInvokedPrecedesRecordedArgs (2.00s)
    fakes_test.go:66: WaitInvoked did not observe the exec
--- FAIL: TestFakeExecutorWaitInvokedStaysSatisfiedAcrossExecs (2.00s)
--- FAIL: TestFakeExecutorRecordsTTYSizesAndReturnsCopies (2.00s)
```

And on the previously flaky test: **16 failures in 60 runs → 0 in 200**, and 4-of-5 race reports → 0 in 5.

Whole-module comparison, run before and after the change in `lego/backend` exactly as `backend-test.yml` does (`go test -p 1 ./...`, `BEX_TEST_DB_URI` and `BEX_TEST_OPENFGA_URL` unset so the integration suites self-skip): 59 packages, identical verdicts, no new failures. The only difference is `internal/sshgateway/gatewaytest` moving from `[no test files]` to `ok`. `golangci-lint run` at the pinned v2.11.4 reports `0 issues`.

One thing deliberately left alone: `gofmt -l` flags a trailing blank line in `multichannel_test.go` at `main` already, so it is not part of this change.

## How this was managed

This work was tracked as [a single story](https://eastagiletracker.com/projects/294/stories/186708) on a board imported from this repository's own issues and pull requests — 35 stories and 6 labels — which you can browse at https://eastagiletracker.com/projects/294.

![board](https://raw.githubusercontent.com/eastagiletracker/bex/agile-board-assets/board.png)

If you'd rather not receive contributions like this, reply `no-more-prs` on this pull request and we won't open any further ones on your repositories.

---

**Lawrence W. Sinclair**
CEO / East Agile
[linkedin.com/in/lwsinclair/](https://linkedin.com/in/lwsinclair/)
[eastagile.com](https://eastagile.com)
